### PR TITLE
Disable autocorrect and autocapitalize

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -176,7 +176,7 @@
             <pre id="output"></pre>
             <div>
                 <div id="sharp" class="sharp"></div>
-                <textarea id="userinput">Loading ...</textarea>
+                <textarea id="userinput" autocorrect="off" autocapitalize="none">Loading ...</textarea>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Small change to disable autocorrect and autocapitalize in textarea (useful on smartphones)